### PR TITLE
Add Dependency Version Constraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires = astor
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = <3.8, >=3.7.6
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Limit Python version <3.8 and >3.7.6 to ensure that astor does not break.